### PR TITLE
Add retry on intermittent fetch errors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,8 @@ commands:
   restore-docker:
     description: Restore Docker image cache
     steps:
-      - setup_remote_docker
+      - setup_remote_docker:
+          version: 19.03.13
       - restore_cache:
           key: v1-{{.Branch}}
       - run:
@@ -20,7 +21,8 @@ jobs:
       - image: docker:stable-git
     steps:
       - checkout
-      - setup_remote_docker
+      - setup_remote_docker:
+          version: 19.03.13
       - run:
           name: Build Docker image
           command: docker build -t app:build .
@@ -34,7 +36,7 @@ jobs:
 
   test:
     docker:
-      - image: docker:18.06.0-ce
+      - image: docker:stable-git
     steps:
       - restore-docker
       - run:


### PR DESCRIPTION
Intermittent error that causes the airflow task to fail.  It's rare so I haven't been able to reproduce it but it always works on retry.

Also docker version needed to be bumped to pass build.  Can't figure that out